### PR TITLE
noticed that setting mapbox z-index to -1 killed all the dynamic ability...

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -598,6 +598,7 @@ $sliding-menu-color-hover: #fff;
   background: rgba(46,117,98,.6);
   border-radius: 20%;
   margin-top: -20px !important;
+  z-index: 9999;
 
   img {
     height: 1.3em;

--- a/app/assets/stylesheets/discovers.css.scss
+++ b/app/assets/stylesheets/discovers.css.scss
@@ -21,7 +21,6 @@ body {
   height: 450px;
   margin: 0 auto 0 auto;
   border-bottom: 8px solid $orange;
-  z-index: -1
 }
 .notes {
   padding-top: 35px;

--- a/app/assets/stylesheets/rambles.css.scss
+++ b/app/assets/stylesheets/rambles.css.scss
@@ -26,7 +26,6 @@
   margin: 0 auto;
   margin-top: 20px;
   border-bottom: 8px solid $orange;
-  z-index: -1
 }
 .recommended-notes {
 }


### PR DESCRIPTION
... of the map. so to fix the aforementioned issue with the sliding-menu-button going behind the map, I removed the z-index specification from the mapbox css, and instead gave sliding-menu-button a z-index: 9999; which resolved the issue without compromising map functionality.
